### PR TITLE
스프링으로 전환 및 스프링 컨테이너 사용하기

### DIFF
--- a/core/src/main/java/moonz/core/AppConfig.java
+++ b/core/src/main/java/moonz/core/AppConfig.java
@@ -1,0 +1,18 @@
+package moonz.core;
+
+import moonz.core.discount.FixDiscountPolicy;
+import moonz.core.member.MemberService;
+import moonz.core.member.MemberServiceImpl;
+import moonz.core.member.MemoryMemberRepository;
+import moonz.core.order.OrderService;
+import moonz.core.order.OrderServiceImpl;
+
+public class AppConfig {
+    public MemberService memberService() {
+        return new MemberServiceImpl(new MemoryMemberRepository());
+    }
+    // orderService에서는 레포지토리와 할인 정책을 사용하므로 생성자에서 2개 모두 주입.
+    public OrderService orderService() {
+        return new OrderServiceImpl(new MemoryMemberRepository(), new FixDiscountPolicy());
+    }
+}

--- a/core/src/main/java/moonz/core/AppConfig.java
+++ b/core/src/main/java/moonz/core/AppConfig.java
@@ -1,18 +1,33 @@
 package moonz.core;
 
-import moonz.core.discount.FixDiscountPolicy;
+import moonz.core.discount.RateDiscountPolicy;
 import moonz.core.member.MemberService;
 import moonz.core.member.MemberServiceImpl;
 import moonz.core.member.MemoryMemberRepository;
 import moonz.core.order.OrderService;
 import moonz.core.order.OrderServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class AppConfig {
+     // 스프링 컨테이너에 등록! 해당 메서드 이름으로 등록됨.
+    @Bean
     public MemberService memberService() {
-        return new MemberServiceImpl(new MemoryMemberRepository());
+        return new MemberServiceImpl(getMemberRepository());
     }
     // orderService에서는 레포지토리와 할인 정책을 사용하므로 생성자에서 2개 모두 주입.
+    @Bean
     public OrderService orderService() {
-        return new OrderServiceImpl(new MemoryMemberRepository(), new FixDiscountPolicy());
+        return new OrderServiceImpl(getMemberRepository(), getDiscountPolicy());
+    }
+    @Bean
+    public MemoryMemberRepository getMemberRepository() {
+        return new MemoryMemberRepository();
+    }
+    @Bean
+    public RateDiscountPolicy getDiscountPolicy() {
+//        return new FixDiscountPolicy();
+        return new RateDiscountPolicy();
     }
 }

--- a/core/src/main/java/moonz/core/MemberApp.java
+++ b/core/src/main/java/moonz/core/MemberApp.java
@@ -3,11 +3,13 @@ package moonz.core;
 import moonz.core.member.Grade;
 import moonz.core.member.Member;
 import moonz.core.member.MemberService;
-import moonz.core.member.MemberServiceImpl;
 
 public class MemberApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
+        //   수정
+        AppConfig appConfig = new AppConfig();
+        MemberService memberService = appConfig.memberService();
+
         Member member = new Member(1L, "memberA", Grade.VIP);   // Ctrl+ alt + V : 변수 생성
         memberService.join(member);
         Member findMember = memberService.findMember(1L);

--- a/core/src/main/java/moonz/core/MemberApp.java
+++ b/core/src/main/java/moonz/core/MemberApp.java
@@ -3,12 +3,20 @@ package moonz.core;
 import moonz.core.member.Grade;
 import moonz.core.member.Member;
 import moonz.core.member.MemberService;
+import moonz.core.member.MemberServiceImpl;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class MemberApp {
     public static void main(String[] args) {
         //   수정
-        AppConfig appConfig = new AppConfig();
-        MemberService memberService = appConfig.memberService();
+//        AppConfig appConfig = new AppConfig();
+//        MemberService memberService = appConfig.memberService();
+
+        // 스프링 : @Bean을 모두 관리하는 스프링 컨테이너 를 생성!
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);    // AppConfig 파일에 있는 환경 설정정보를 이용해서 Spring Container에 객체를 넣어서 관리하도록 한다.
+        // 스프링 :  직접 찾아오는게아닌 스프링 컨테이너를 통해서 가져온다. @Bean 등록한 메서드 이름과 타입으로 찾아 꺼낸다.
+        MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
 
         Member member = new Member(1L, "memberA", Grade.VIP);   // Ctrl+ alt + V : 변수 생성
         memberService.join(member);

--- a/core/src/main/java/moonz/core/OrderApp.java
+++ b/core/src/main/java/moonz/core/OrderApp.java
@@ -10,8 +10,14 @@ import moonz.core.order.OrderServiceImpl;
 //TEST (수동)
 public class OrderApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
-        OrderService orderService = new OrderServiceImpl();
+        // 수정
+        MemberService memberService;
+        OrderService orderService;
+
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+        orderService = appConfig.orderService();
+
         // 멤버 생성
         long memberId = 1L;
         Member member = new Member(memberId, "memberA", Grade.VIP);

--- a/core/src/main/java/moonz/core/OrderApp.java
+++ b/core/src/main/java/moonz/core/OrderApp.java
@@ -7,17 +7,25 @@ import moonz.core.member.MemberServiceImpl;
 import moonz.core.order.Order;
 import moonz.core.order.OrderService;
 import moonz.core.order.OrderServiceImpl;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 //TEST (수동)
 public class OrderApp {
     public static void main(String[] args) {
         // 수정
-        MemberService memberService;
-        OrderService orderService;
+//        MemberService memberService;
+//        OrderService orderService;
+//
+//        AppConfig appConfig = new AppConfig();
+//        memberService = appConfig.memberService();
+//        orderService = appConfig.orderService();
 
-        AppConfig appConfig = new AppConfig();
-        memberService = appConfig.memberService();
-        orderService = appConfig.orderService();
-
+        // 스프링 : 스프링컨테이너 생성
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        // 스프링 : 스프링 컨테이너에서 객체를 찾아서 꺼내온다. (등록된 메서드명, 꺼낼 클래스 타입)
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+        OrderService orderService = ac.getBean("orderService", OrderService.class);
         // 멤버 생성
         long memberId = 1L;
         Member member = new Member(memberId, "memberA", Grade.VIP);

--- a/core/src/main/java/moonz/core/member/MemberServiceImpl.java
+++ b/core/src/main/java/moonz/core/member/MemberServiceImpl.java
@@ -1,12 +1,17 @@
 package moonz.core.member;
 
 public class MemberServiceImpl implements MemberService {
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
+    private final MemberRepository memberRepository;
+
+    public MemberServiceImpl(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
 
     @Override
     public void join(Member member) {
         memberRepository.save(member);
-    }
+    }   // 인터페이스만 보고 개발하면 된다!
 
     @Override
     public Member findMember(Long memberId) { // 관례: 구현체가 1개인 경우 "인터페이스명+Impl"

--- a/core/src/main/java/moonz/core/order/OrderServiceImpl.java
+++ b/core/src/main/java/moonz/core/order/OrderServiceImpl.java
@@ -1,14 +1,18 @@
 package moonz.core.order;
 
 import moonz.core.discount.DiscountPolicy;
-import moonz.core.discount.FixDiscountPolicy;
 import moonz.core.member.Member;
 import moonz.core.member.MemberRepository;
-import moonz.core.member.MemoryMemberRepository;
 
 public class OrderServiceImpl implements OrderService{
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
-    private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
+    // 오직 추상화에만 의존!
+    private final MemberRepository memberRepository;
+    private final DiscountPolicy discountPolicy;  // DIP 지킨 모습! final은 초기화를 해줘야하므로 지워준다.
+
+    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/core/src/test/java/moonz/core/member/MemberServiceTest.java
+++ b/core/src/test/java/moonz/core/member/MemberServiceTest.java
@@ -1,10 +1,17 @@
 package moonz.core.member;
 
+import moonz.core.AppConfig;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MemberServiceTest {
-    MemberService memberService = new MemberServiceImpl();
+    MemberService memberService;
+    @BeforeEach
+    void beforeEach() {
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+    }
     @Test
     void join() {
         //given

--- a/core/src/test/java/moonz/core/order/OrderServiceTest.java
+++ b/core/src/test/java/moonz/core/order/OrderServiceTest.java
@@ -1,15 +1,23 @@
 package moonz.core.order;
 
+import moonz.core.AppConfig;
 import moonz.core.member.Grade;
 import moonz.core.member.Member;
 import moonz.core.member.MemberService;
-import moonz.core.member.MemberServiceImpl;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class OrderServiceTest {
-    MemberService memberService = new MemberServiceImpl();
-    OrderService orderService = new OrderServiceImpl();
+    //   수정
+    MemberService memberService;
+    OrderService orderService;
+    @BeforeEach
+    void beforeEach() {
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+        orderService = appConfig.orderService();
+    }
 
     @Test
     void createOrder() {


### PR DESCRIPTION
### 기존에 직접 작성한 자바코드를 스프링으로 전환하기
- 기존에 스프링 컨테이너 역할을 하던 AppConfig 대신 스프링이 제공하는 기능으로 편하게 구현 가능하다.
  - `ApplicationContext` : 스프링 컨테이너
  -  `@Configuration` 이 붙은 AppConfig 를 설정(구성) 정보로 사용하며, 여기서 `@Bean`이라 적힌 메서드를 모두 호출해서 반환된 객체를 스프링 컨테이너에 등록한다. 

### 스프링 컨테이너
- 스프링 컨테이너에 객체를 스프링 빈으로 등록하고, 스프링 컨테이너에서 스프링 빈을 찾아서 사용하도록 변경되었다.