### PR TITLE
테스트코드 수정/중복 빈 등록

### DIFF
--- a/core/src/main/java/moonz/core/AutoAppConfig.java
+++ b/core/src/main/java/moonz/core/AutoAppConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
-@Configuration
+@Configuration  // 중복된 객체를 생성하지 않고 등록한 빈을 주입하도록 함
 @ComponentScan(
         basePackages = "moonz.core",    // 만약 moonz.core.member로 하면 member 아래부터 컴포넌트  탐색됨
         excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class) // 수동으로 등록하는 AppConfig 파일을 제외 !
@@ -26,6 +26,10 @@ public class AutoAppConfig {
         this.discountPolicy = discountPolicy;
     }
 
+    // 수동 빈 등록이 우선권을 가진다. (자동 빈을 오버라이딩) =>
+    // 이제는 중복 빈 등록 시 에러 발생시킴
+    // : Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true
+/*
     @Bean
     OrderService orderService() {
         return new OrderServiceImpl(memberRepository, discountPolicy);
@@ -35,4 +39,5 @@ public class AutoAppConfig {
     MemberRepository memberRepository() {
         return new MemoryMemberRepository();
     }
+*/
 }

--- a/core/src/main/java/moonz/core/member/MemberServiceImpl.java
+++ b/core/src/main/java/moonz/core/member/MemberServiceImpl.java
@@ -9,7 +9,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     @Autowired  // ac.getBean(MemberRepository.class)
-    public MemberServiceImpl(@Qualifier("memberRepository") MemberRepository memberRepository) {
+    public MemberServiceImpl(@Qualifier("memoryMemberRepository") MemberRepository memberRepository) {    // @Qualifier() : 특정한 객체를 찾기위한 이름을 지정
         this.memberRepository = memberRepository;
     }
 

--- a/core/src/main/java/moonz/core/member/MemoryMemberRepository.java
+++ b/core/src/main/java/moonz/core/member/MemoryMemberRepository.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.Map;
 
-@Component
+@Component  // 자동 빈 등록
 public class MemoryMemberRepository implements MemberRepository{
     private static Map<Long, Member> store = new HashMap<>();  // 실무에서는 동시성 문제때문에 cuncurrent hashmap을 써야함.
     // 주의 : Map을 static으로 생성하지 않으면 다른 곳에서 같은 메로리를 공유하지 못함

--- a/core/src/main/java/moonz/core/order/OrderServiceImpl.java
+++ b/core/src/main/java/moonz/core/order/OrderServiceImpl.java
@@ -12,7 +12,7 @@ public class OrderServiceImpl implements OrderService{
     private MemberRepository memberRepository;
     private DiscountPolicy discountPolicy;  // DIP 지킨 모습! final을 설정함으로써 (생성자를 통해) 초기화를 무조건 해줘야한다.(setter 생성할 경우 지워줘야한다.)
 
-    // 수정자 주입 : setter를 생성해줄 경우 final 키워드 없이 객체를 선언해야한다.
+    /* 수정자 주입 : setter를 생성해줄 경우 final 키워드 없이 객체를 선언해야한다.
     @Autowired
     public void setMemberRepository(MemberRepository memberRepository) {    // memberRepository가 스프링 빈으로 등록 안됐을 수도 있음. 선택적으로 주입 가능하다.
         this.memberRepository = memberRepository;
@@ -20,8 +20,8 @@ public class OrderServiceImpl implements OrderService{
     @Autowired
     public void setDiscountPolicy(DiscountPolicy discountPolicy) {
         this.discountPolicy = discountPolicy;
-    }
-    @Autowired  // 생성자에서 여러 의존관계도 한번에 주입받을 수 있다.
+    } */
+    @Autowired  // 생성자에서 여러 의존관계를 한번에 주입받을 수 있다.
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;


### PR DESCRIPTION
### 수동 빈 등록과 자동 빈 등록의 경우
- 원래는 수동 빈 등록(`AutoAppConfig`에서 직접 `@Bean 등록`)이 
  자동 빈 등록(`@Component`)을 오버라이딩했는데, 현재 버전의 Spring Boot는 에러가 발생한다.

`Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true`