### PR TITLE
@Qualifier 대체 애너테이션 생성

### DIFF
--- a/core/src/main/java/moonz/core/annotation/MainDiscountPolicy.java
+++ b/core/src/main/java/moonz/core/annotation/MainDiscountPolicy.java
@@ -1,0 +1,13 @@
+package moonz.core.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE})  // 애노테이션 적용 위치
+@Retention(RetentionPolicy.RUNTIME) // 어노테이션을 유지하는 정책 설정
+@Inherited      // 애너테이션이 MainDidscountPolicy의 자손 클래스에도 상속되도록 한다.
+@Documented // javadoc으로 api 문서를 만들 때 해당 애노테이션에 대한 설명도 포함하도록 지정
+@Qualifier("mainDiscountPolicy") // 추가
+public @interface MainDiscountPolicy {
+}

--- a/core/src/main/java/moonz/core/discount/RateDiscountPolicy.java
+++ b/core/src/main/java/moonz/core/discount/RateDiscountPolicy.java
@@ -1,5 +1,6 @@
 package moonz.core.discount;
 
+import moonz.core.annotation.MainDiscountPolicy;
 import moonz.core.member.Grade;
 import moonz.core.member.Member;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -7,8 +8,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
-//@Qualifier("mainDiscountPolicy")
-@Primary
+@MainDiscountPolicy //@Qualifier("mainDiscountPolicy") : 컴파일 시 체크 x
 public class RateDiscountPolicy implements DiscountPolicy {
     private int discountPercent = 10;
 

--- a/core/src/main/java/moonz/core/order/OrderServiceImpl.java
+++ b/core/src/main/java/moonz/core/order/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package moonz.core.order;
 
 import lombok.RequiredArgsConstructor;
+import moonz.core.annotation.MainDiscountPolicy;
 import moonz.core.discount.DiscountPolicy;
 import moonz.core.member.Member;
 import moonz.core.member.MemberRepository;
@@ -25,7 +26,7 @@ public class OrderServiceImpl implements OrderService{
         this.discountPolicy = discountPolicy;
     } */
     @Autowired  // 생성자에서 여러 의존관계를 한번에 주입받을 수 있다.
-    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;
     }


### PR DESCRIPTION
### 애너테이션을 생성하여 @Qualifier 대체
이전에 `@Qualifier`를 이용하여 우선순위를 지정하는 방식을 대체한다.

**기존 문제**
- `@Qualifier("mainDiscountPolicy")`에 오타가 발생해도 컴파일 타임 시 에러가 발생하지 않는다. (문자이기 때문)

**해결**
-  MainDiscountPolicy 애너테이션을 생성하여 해당 애너테이션에 `@Qualifier("mainDiscountPolicy")`를 지정한다.