### PR TITLE
 Spring_Boot_and_JPA #2: 주문조회 V3: 패치조인 활용

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,81 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.dto.SimpleOrderDto;
+import jpabook.jpashop.repository.OrderRepositoryV1;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+x to one (many to one, one to one)
+ */
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+    private final OrderRepositoryV1 orderRepository;
+
+    /*
+     단점
+     1. Entity를 API 응답에 그대로 노출하면 안된다.
+      - why? 복잡한 JSON 응답이 생성된다. 배열 안에 배열 안에 배열..
+      - 실제 응답 시에는 아래와 같이 모든 Entity필드를 API에 노출하는게 아닌,
+       memberName, deliveryId, ..와 같이 필요한 필드만 노출시키는게 맞다.
+      {
+        "member": {
+          "id": 1,
+          "name": "userA", ..
+        },
+        ..
+      }
+     2. Entity에서 필드에 지정한 Lazy로딩 전략으로 인해 문제 발생
+     */
+    @GetMapping("/api/v1/simple-orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAllByJPQL(new OrderSearch());
+        for (Order order : all) {
+            System.out.println(order.getOrderItems().get(0).getItem().getName());
+        }
+        return all;
+    }
+    /*
+    DTO 반환
+    * 실무에서는 응답 객체로 List를 한번 더 감아야한다!
+    N+1 문제
+    * Order를 조회할 때 SimpleOrderDto의 필드로 인해 Member와 Delivery의 값을 조회하게 됨.
+    * 그래서 각각 Member와 Delivery 조회 쿼리문이 발생하고, LAZY 초기화를 진행함.
+    * 결국 Order 2개 조회 시 + Member2번 Delivery2번 조회 =>  1 + 2 + 2 = 5번 발생
+    * 주문 1 + 회원 N + 배송 N
+    * 1번 쿼리 실행할 때, N번 추가 쿼리가 실행되는 것이 N+1 문제이다.
+     */
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> ordersV2() {
+        List<Order> allOrders = orderRepository.findAllByJPQL(new OrderSearch());
+        return allOrders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Order 조회 시 한번에 Member와 Delivery를 한번에 조인해서 가져온다.
+     * 이때는 LAZY 를 무시하고 직접 데이터를 가져온다.
+     */
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> orderV3() {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        return orders.stream().map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<SimpleOrderDto> orderV4() {
+        orderRepository.findOrderDtos();
+        // 작성중
+        return null;
+    }
+
+}

--- a/jpashop/src/main/java/jpabook/jpashop/dto/SimpleOrderDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/dto/SimpleOrderDto.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.dto;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SimpleOrderDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+    // 중요하지 않은 Entity에서 중요한 Entity로의 의존은 ㄱㅊ
+    public SimpleOrderDto(Order order) {
+        orderId = order.getId();
+        name = order.getMember().getName();     /* LAZY 초기화 */
+        orderDate = order.getOrderDate();
+        orderStatus = order.getStatus();
+        address = order.getDelivery().getAddress();     /* LAZY 초기화 */
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/initDb.java
+++ b/jpashop/src/main/java/jpabook/jpashop/initDb.java
@@ -1,0 +1,87 @@
+package jpabook.jpashop;
+
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.domain.item.Book;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+
+/**
+ * userA
+ *   JPA1
+ *   JPA2
+ * userB
+ *   SPRING1
+ *   SPRING2
+ */
+@Component
+@RequiredArgsConstructor
+public class initDb {
+
+    private final InitService initService;
+
+    @PostConstruct  // Spring이 모두 로드되고 나면 호출된다.
+    public void init() {
+        initService.dbInit1();  // 여기에 트랜잭션 로직이 들어가면 실행 안됨.
+        initService.dbInit2();
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    @Transactional
+    static class InitService{
+        private final EntityManager em;
+        public void dbInit1() {
+            Member member = createMember("문윤지", "서울", "1", "1111");
+            em.persist(member);
+
+            Book book1 = createBook("홍길동", "isbn", "JPA1 BOOK", 10000, 100);
+            em.persist(book1);
+
+            Book book2 = createBook("김영한", "isbn2", "JPA2 BOOK", 20000, 100);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+
+            Delivery delivery = new Delivery(member.getAddress(), DeliveryStatus.READY);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        public void dbInit2() {
+            Member member = createMember("문지", "진주", "2", "2222");
+            em.persist(member);
+
+            Book book1 = createBook("홍길은", "isbn", "SPRING1 BOOK", 20000, 200);
+            em.persist(book1);
+
+            Book book2 = createBook("김영한", "isbn2", "SPRING2 BOOK", 40000, 300);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+
+            Delivery delivery = new Delivery(member.getAddress(), DeliveryStatus.READY);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private Member createMember(String name, String city, String street, String zipcode) {
+            return Member.builder()
+                    .name(name)
+                    .address(new Address(city, street, zipcode))
+                    .build();
+        }
+
+        private Book createBook(String author, String isbn, String name, int price, int stockQuantity) {
+            return Book.createBook(author, isbn, name, price, stockQuantity);
+        }
+    }
+
+
+}
+

--- a/jpashop/src/main/java/jpabook/jpashop/repository/BookRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/BookRepository.java
@@ -3,5 +3,5 @@ package jpabook.jpashop.repository;
 import jpabook.jpashop.domain.item.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BookRepository extends JpaRepository<Book, Long>, ItemRepository<Book> {
+public interface BookRepository extends JpaRepository<Book, Long> {
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface ItemRepository<T extends Item> extends JpaRepository<T, Long> {
-    Optional<T> findOne(Long itemId);
+    Optional<T> findById(Long itemId);
     /*final EntityManager em;
 
     public void save(Item item) {

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryCustom.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryCustom.java
@@ -1,0 +1,10 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.Order;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepositoryCustom {
+    Optional<List<Order>> findAllByQueryDsl(OrderSearch orderSearch);
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryCustomImpl.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package jpabook.jpashop.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jpabook.jpashop.domain.Order;
+import static jpabook.jpashop.domain.QOrder.*;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom{
+    private final JPAQueryFactory query;
+
+    /**
+     * QueryDsl로 작성한 주문 검색 기능
+     * - 검색 조건에 동적으로 쿼리 생성하여 주문 엔티티 조회
+     * @return
+     */
+    @Override
+    public Optional<List<Order>> findAllByQueryDsl(OrderSearch orderSearch) {
+        return Optional.ofNullable(
+            query.selectFrom(order)
+                .fetch()
+        );
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryV1.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepositoryV1.java
@@ -2,6 +2,7 @@ package jpabook.jpashop.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.dto.SimpleOrderDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,14 +10,13 @@ import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.*;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import static org.springframework.util.StringUtils.*;
+import static org.springframework.util.StringUtils.hasText;
 
 @Repository
 @RequiredArgsConstructor
-public class OrderRepository {
+public class OrderRepositoryV1 {
     private final EntityManager em;
     private final JPAQueryFactory query;
 
@@ -96,11 +96,14 @@ public class OrderRepository {
         return query.getResultList();
     }
 
-    /**
-     * QueryDsl로 작성한 주문 검색 기능
-     */
-    public List<Order> findAll(OrderSearch orderSearch) {
-//        query.select()
-        return Collections.emptyList();
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery("select o from Order o" +
+                " join fetch o.member m" +
+                " join fetch o.delivery d", Order.class
+        ).getResultList();
+    }
+
+    public List<SimpleOrderDto> findOrderDtos() {
+
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/temp_OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/temp_OrderRepository.java
@@ -1,0 +1,8 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface temp_OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+
+}


### PR DESCRIPTION
- JPA 패치조인 이용하여 쿼리 성능 개선
- 기존 : Order 엔티티와 연관된 Member, Delivery에 대해 각각 쿼리를 생성했다. 
   - 예) Order 엔티티가 2개이면, Member&Delivery 각각 2개씩 추가로 쿼리문이 생성된다.
- 수정 후 : Order 엔티티와 연관된 Member, Delivery에 대해 fetch join을 이용해 하나의 쿼리문만 생성된다. (inner, outer 조인 모두 가능)